### PR TITLE
Added Configurable Aliases

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>edu.whimc</groupId>
 	<artifactId>WHIMC-ScienceTools</artifactId>
-	<version>2.2.1</version>
+	<version>2.3.0</version>
 	<name>WHIMC Science Tools</name>
 	<description>Simulate values for scientific tools</description>
 

--- a/src/main/java/edu/whimc/sciencetools/models/sciencetool/NumericScienceTool.java
+++ b/src/main/java/edu/whimc/sciencetools/models/sciencetool/NumericScienceTool.java
@@ -29,6 +29,7 @@ public class NumericScienceTool extends ScienceTool {
      *
      * @param toolKey The key for this tool in the config.
      * @param displayName The name to be displayed in-game for this tool.
+     * @param aliases Alternate names for the tool.
      * @param defaultMeasurement The default measurement used when no region or world value is found.
      * @param worldMeasurements The world-specific global measurements.
      * @param regionMeasurements The region-specific measurements.
@@ -39,6 +40,7 @@ public class NumericScienceTool extends ScienceTool {
      */
     public NumericScienceTool(String toolKey,
                               String displayName,
+                              List<String> aliases,
                               String defaultMeasurement,
                               Map<World, String> worldMeasurements,
                               Map<World, Map<String, String>> regionMeasurements,
@@ -46,7 +48,7 @@ public class NumericScienceTool extends ScienceTool {
                               String unit,
                               int precision,
                               List<Conversion> conversions) {
-        super(toolKey, displayName, defaultMeasurement, worldMeasurements, regionMeasurements, disabledWorlds);
+        super(toolKey, displayName, aliases, defaultMeasurement, worldMeasurements, regionMeasurements, disabledWorlds);
         this.unit = unit;
         this.precision = precision;
         this.conversions = conversions;

--- a/src/main/java/edu/whimc/sciencetools/models/sciencetool/ScienceTool.java
+++ b/src/main/java/edu/whimc/sciencetools/models/sciencetool/ScienceTool.java
@@ -32,6 +32,8 @@ public class ScienceTool {
     protected String toolKey;
     /* Displayed when referencing the tool in game. */
     protected String displayName;
+    /* Aliases for the command. */
+    protected List<String> aliases;
 
     /* Default measurement to be used when no region or world measurement is found. */
     protected String defaultMeasurement;
@@ -50,6 +52,7 @@ public class ScienceTool {
      *
      * @param toolKey The tool's key within the config.
      * @param displayName The tool's in-game name.
+     * @param aliases Alternate names for the tool.
      * @param defaultMeasurement The measurement used when no region- or world-specific measurements are found.
      * @param worldMeasurements All world-specific global measurements.
      * @param regionMeasurements All region-specific measurements.
@@ -57,12 +60,14 @@ public class ScienceTool {
      */
     public ScienceTool(String toolKey,
                        String displayName,
+                       List<String> aliases,
                        String defaultMeasurement,
                        Map<World, String> worldMeasurements,
                        Map<World, Map<String, String>> regionMeasurements,
                        Set<World> disabledWorlds) {
         this.toolKey = toolKey;
         this.displayName = displayName;
+        this.aliases = aliases;
         this.defaultMeasurement = defaultMeasurement;
         this.worldMeasurements = worldMeasurements;
         this.regionMeasurements = regionMeasurements;
@@ -170,8 +175,8 @@ public class ScienceTool {
 
         private MeasureCommand() {
             super(ScienceTool.this.toolKey, "Measure the " + ScienceTool.this.displayName,
-                    "", Collections.emptyList());
-
+                    "", ScienceTool.this.aliases);
+            
             if (!getCommandMap().register("WHIMC-ScienceTools", this)) {
                 Utils.log("&c\t- Error registering /" + ScienceTool.this.toolKey);
             }

--- a/src/main/java/edu/whimc/sciencetools/models/sciencetool/ScienceToolManager.java
+++ b/src/main/java/edu/whimc/sciencetools/models/sciencetool/ScienceToolManager.java
@@ -65,6 +65,19 @@ public class ScienceToolManager {
 
             ConfigurationSection section = config.getConfigurationSection("tools." + toolKey);
 
+            // Load aliases
+            Utils.log("&b\t- Aliases:");
+            List<String> aliases = new ArrayList<String>();
+            for (String alias : section.getStringList("aliases")) {
+            	// Ensure aliases do not contain spaces
+            	if (alias.contains(" ")) {
+            		Utils.log("&c* Alias cannot contain whitespace! Skipping.");
+                    continue;
+            	}
+            	aliases.add(alias);
+            	Utils.log("&b\t\t- \"&f" + alias + "&b\"");
+            }
+            
             // Ensure there is a default measurement
             String defaultMeasurement = section.getString("default-measurement");
             if (defaultMeasurement == null) {
@@ -132,7 +145,7 @@ public class ScienceToolManager {
             // If the default measurement is not a valid numeric expression, parse as a string-based science tool
             JSNumericExpression defaultExpression = new JSNumericExpression(defaultMeasurement);
             if (!defaultExpression.valid()) {
-                ScienceTool tool = new ScienceTool(toolKey, displayName, defaultMeasurement, worldMeasurements,
+                ScienceTool tool = new ScienceTool(toolKey, displayName, aliases, defaultMeasurement, worldMeasurements,
                         worldRegionMeasurements, disabledWorlds);
                 this.tools.put(toolKey.toLowerCase(), tool);
                 continue;
@@ -164,7 +177,7 @@ public class ScienceToolManager {
                 }
             }
 
-            NumericScienceTool tool = new NumericScienceTool(toolKey, displayName, defaultMeasurement,
+            NumericScienceTool tool = new NumericScienceTool(toolKey, displayName, aliases, defaultMeasurement,
                     worldMeasurements, worldRegionMeasurements, disabledWorlds, unit, precision, conversions);
             this.tools.put(toolKey.toLowerCase(), tool);
             JSPlaceholder.registerCustomPlaceholder(tool);


### PR DESCRIPTION
Aliases can now be added in the config:
```yml
 RADIATION_PARTICLE:
    display-name: "particle radiation"
    aliases: [radiation_nuclear, nuclear]
    default-measurement: "2.4"
    unit: "mSv"
```

Resolves #30 