### PR TITLE
Disabled worlds still showing measurement

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>edu.whimc</groupId>
     <artifactId>WHIMC-ScienceTools</artifactId>
-    <version>2.4.6</version>
+    <version>2.4.7</version>
     <name>WHIMC Science Tools</name>
     <description>Simulate values for scientific tools</description>
     <repositories>

--- a/src/main/java/edu/whimc/sciencetools/models/sciencetool/NumericScienceTool.java
+++ b/src/main/java/edu/whimc/sciencetools/models/sciencetool/NumericScienceTool.java
@@ -62,12 +62,12 @@ public class NumericScienceTool extends ScienceTool {
      */
     @Override
     public @Nullable String displayMeasurement(Player player) {
-        // check if player in disabled world
-
+        // Check if the player is in a disabled world
         if (super.disabledWorlds.contains(player.getWorld())) {
             Utils.msg(player, Message.DISABLED_IN_WORLD.format(this, player));
             return null;
         }
+
         String message = Message.NUMERIC_MEASURE.format(this, player);
         double data = getData(player.getLocation());
 

--- a/src/main/java/edu/whimc/sciencetools/models/sciencetool/ScienceTool.java
+++ b/src/main/java/edu/whimc/sciencetools/models/sciencetool/ScienceTool.java
@@ -149,9 +149,12 @@ public class ScienceTool {
      * @return The measurement
      */
     public @Nullable String displayMeasurement(Player player) {
+        // Check if the player is in a disabled world
         if (this.disabledWorlds.contains(player.getWorld())) {
             Utils.msg(player, Message.DISABLED_IN_WORLD.format(this, player));
+            return null;
         }
+
         String measurement = Message.MEASURE.format(this, player);
         Utils.msg(player, measurement);
         return measurement;


### PR DESCRIPTION
Measurements on disabled worlds will now properly fail without also sending the measurement to the player.