### PR TITLE
Fix console errors when no SQL connection is established

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,11 @@ $ mvn install
 The config file can be found under `/plugins/WHIMC-ScienceTools/config.yml`. Use `/sciencetools reload` whenever you change the config.
 
 ### MySQL
+In order to track the history of science tool usage, you have to connect to a SQL database.
+
 | Key | Type | Description |
 |---|---|---|
+|`mysql.enabled`|`boolean`|Whether to use a SQL database|
 |`mysql.host`|`string`|The host of the database|
 |`mysql.port`|`integer`|The port of the database|
 |`mysql.database`|`string`|The name of the database to use|
@@ -30,6 +33,7 @@ The config file can be found under `/plugins/WHIMC-ScienceTools/config.yml`. Use
 #### Example
 ```yaml
 mysql:
+  enabled: true
   host: localhost
   port: 3306
   database: minecraft
@@ -172,7 +176,7 @@ Region names are defined using [WorldGuard](https://worldguard.enginehub.org/en/
 |`randInt(min, max)`| A random integer between `min` and `max` (inclusive) |
 |`min(a, b)`        | The minimum between `a` and `b`                      |
 |`max(a, b)`        | The maximum between `a` and `b`                      |
-| `{<tool key>}`    | The value from the given _numeric_ tool 
+| `{<tool key>}`    | The value from the given _numeric_ tool              |
 
 ### Validation
 Validation config will look like this:
@@ -314,6 +318,7 @@ validation:
 | `/sciencetools reload`                                      | Reload the plugin's config                                         |
 | `/sciencetools js`                                          | Run interpreted JavaScript                                         |
 | `/sciencetools measure <tool>`                              | Measure the given science tool                                     |
+| `/sciencetools history <player>`                            | View the science tool usage history of a player                    |
 
 &nbsp;
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>edu.whimc</groupId>
     <artifactId>WHIMC-ScienceTools</artifactId>
-    <version>2.4.8</version>
+    <version>2.4.9</version>
     <name>WHIMC Science Tools</name>
     <description>Simulate values for scientific tools</description>
     <repositories>

--- a/src/main/java/edu/whimc/sciencetools/commands/subcommands/History.java
+++ b/src/main/java/edu/whimc/sciencetools/commands/subcommands/History.java
@@ -34,6 +34,10 @@ public class History extends AbstractSubCommand {
     @Override
     protected boolean commandRoutine(CommandSender sender, String[] args) {
         // TODO Display measurements in a GUI
+        if (ScienceTools.getInstance().getQueryer() == null) {
+            Utils.msg(sender, "&c&oThis command is disabled!");
+            return false;
+        }
 
         // display sender's measurements
         if (args.length == 0 || !sender.hasPermission(Permission.ADMIN.toString())) {

--- a/src/main/java/edu/whimc/sciencetools/utils/Utils.java
+++ b/src/main/java/edu/whimc/sciencetools/utils/Utils.java
@@ -19,6 +19,7 @@ import org.bukkit.entity.Player;
 public class Utils {
 
     private static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("MMMM d yyyy, h:mm a z");
+    private static final String prefix = '[' + ScienceTools.getInstance().getDescription().getName() + "] ";
     private static CommandSender debugReceiver = null;
 
     /**
@@ -96,7 +97,7 @@ public class Utils {
         if (debugReceiver != null) {
             Utils.msg(debugReceiver, message);
         }
-        ScienceTools.getInstance().getLogger().info(colored(message));
+        Bukkit.getConsoleSender().sendMessage(prefix + colored(message));
     }
 
     /**

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,5 +1,6 @@
 # -- WHIMC Science Tools --
 mysql:
+  enabled: true
   host: localhost
   port: 3306
   database: minecraft


### PR DESCRIPTION
* Add config to explicitly disable MySQL (`mysql.enabled`)
* Gracefully handle when no database connection could be established