### PR TITLE
Decimal place adjust

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>edu.whimc</groupId>
     <artifactId>WHIMC-ScienceTools</artifactId>
-    <version>2.4.10</version>
+    <version>2.4.11</version>
     <name>WHIMC Science Tools</name>
     <description>Simulate values for scientific tools</description>
     <repositories>

--- a/src/main/java/edu/whimc/sciencetools/models/conversion/Conversion.java
+++ b/src/main/java/edu/whimc/sciencetools/models/conversion/Conversion.java
@@ -20,6 +20,8 @@ public class Conversion {
     private String unit;
     /* The expression to calculate the passed value in the new unit*/
     private JSNumericExpression expression;
+    /* The decimal precision of the tool. */
+    private final int precision;
 
     /**
      * Constructs a Conversion.
@@ -27,11 +29,13 @@ public class Conversion {
      * @param name       The name of the Conversion.
      * @param unit       The unit being converted to.
      * @param expression The Conversion equation.
+     * @param precision  The number of places after the decimal place to include
      */
-    protected Conversion(String name, String unit, JSNumericExpression expression) {
+    protected Conversion(String name, String unit, JSNumericExpression expression, int precision) {
         this.name = name;
         this.unit = unit;
         this.expression = expression;
+        this.precision = precision;
     }
 
     /**
@@ -50,6 +54,10 @@ public class Conversion {
 
     public String getUnit() {
         return this.unit;
+    }
+
+    public int getPrecision() {
+        return this.precision;
     }
 
     /**
@@ -86,7 +94,8 @@ public class Conversion {
         Utils.msg(sender,
                 getName() + ":",
                 "  Expression: " + getExpression(),
-                "  Unit: " + getUnit());
+                "  Unit: " + getUnit(),
+                "  Precision: " + getPrecision());
     }
 
 }

--- a/src/main/java/edu/whimc/sciencetools/models/conversion/ConversionManager.java
+++ b/src/main/java/edu/whimc/sciencetools/models/conversion/ConversionManager.java
@@ -3,11 +3,11 @@ package edu.whimc.sciencetools.models.conversion;
 import edu.whimc.sciencetools.ScienceTools;
 import edu.whimc.sciencetools.javascript.JSNumericExpression;
 import edu.whimc.sciencetools.utils.Utils;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.jetbrains.annotations.NotNull;
+import scala.Int;
 
 /**
  * Handles operations regarding Conversions (adding, removing, saving, loading).
@@ -36,9 +36,11 @@ public class ConversionManager {
             Utils.log("&b - &f" + conversion);
             String expr = config.getString("conversions." + conversion + ".expression");
             String unit = config.getString("conversions." + conversion + ".unit");
+            int precision = config.getInt("conversions." + conversion + ".precision"); //no idea if this needs to go in the log
 
             Utils.log("&b\t- Expression: \"&f" + expr + "&b\"");
             Utils.log("&b\t- Unit: \"&f" + unit + "&b\"");
+            Utils.log("&b\t- Precision: \"&f" + precision + "&b\"");
 
             // ensure conversion's expression is valid, skip if not
             JSNumericExpression jsExpr = new JSNumericExpression(expr);
@@ -47,7 +49,7 @@ public class ConversionManager {
                 continue;
             }
 
-            loadConversion(conversion, unit, jsExpr);
+            loadConversion(conversion, unit, jsExpr, precision);
         }
 
         Utils.log("&eConversions loaded!");
@@ -59,10 +61,11 @@ public class ConversionManager {
      * @param name The name of the Conversion.
      * @param unit The unit being converted to.
      * @param expr The Conversion equation.
+     * @param precision The number of places after the decimal place to include.
      * @return The Conversion.
      */
-    private @NotNull Conversion loadConversion(String name, String unit, JSNumericExpression expr) {
-        Conversion conversion = new Conversion(name, unit, expr);
+    private @NotNull Conversion loadConversion(String name, String unit, JSNumericExpression expr, int precision) {
+        Conversion conversion = new Conversion(name, unit, expr, precision);
         conversions.put(name, conversion);
         return conversion;
     }
@@ -75,8 +78,8 @@ public class ConversionManager {
      * @param expr The Conversion equation.
      * @return The Conversion.
      */
-    public Conversion createConversion(String name, String unit, JSNumericExpression expr) {
-        Conversion conversion = loadConversion(name, unit, expr);
+    public Conversion createConversion(String name, String unit, JSNumericExpression expr, int precision) {
+        Conversion conversion = loadConversion(name, unit, expr, precision);
         saveToConfig(conversion);
         return conversion;
     }

--- a/src/main/java/edu/whimc/sciencetools/models/conversion/ConversionManager.java
+++ b/src/main/java/edu/whimc/sciencetools/models/conversion/ConversionManager.java
@@ -36,7 +36,8 @@ public class ConversionManager {
             Utils.log("&b - &f" + conversion);
             String expr = config.getString("conversions." + conversion + ".expression");
             String unit = config.getString("conversions." + conversion + ".unit");
-            int precision = config.getInt("conversions." + conversion + ".precision"); //no idea if this needs to go in the log
+            int precision = config.getInt("conversions." + conversion + ".precision");
+            //no idea if this needs to go in the log ^
 
             Utils.log("&b\t- Expression: \"&f" + expr + "&b\"");
             Utils.log("&b\t- Unit: \"&f" + unit + "&b\"");

--- a/src/main/java/edu/whimc/sciencetools/models/sciencetool/NumericScienceTool.java
+++ b/src/main/java/edu/whimc/sciencetools/models/sciencetool/NumericScienceTool.java
@@ -73,7 +73,10 @@ public class NumericScienceTool extends ScienceTool {
 
         // display converted values
         for (Conversion conversion : conversions) {
-            String converted = Utils.trimDecimals(conversion.convert(data), precision);
+            //fixing precision to always be a certain number of decimals so regular measures can be set to precision 0
+            //Jack the reason for this is that kids would read 1.000 as one-thousand too easily due to the MC font
+            //So for instance on gravity I've made it an integer percent
+            String converted = Utils.trimDecimals(conversion.convert(data), 3);
             message += " (" + converted + conversion.getUnit() + ")";
         }
 

--- a/src/main/java/edu/whimc/sciencetools/models/sciencetool/NumericScienceTool.java
+++ b/src/main/java/edu/whimc/sciencetools/models/sciencetool/NumericScienceTool.java
@@ -73,9 +73,8 @@ public class NumericScienceTool extends ScienceTool {
 
         // display converted values
         for (Conversion conversion : conversions) {
-            //fixing precision to always be a certain number of decimals so regular measures can be set to precision 0
-            //Jack the reason for this is that kids would read 1.000 as one-thousand too easily due to the MC font
-            //So for instance on gravity I've made it an integer percent
+            //conversions now have their own separate precision; not sure what happens if it's left out of the config?
+            //does an unassigned int in Java have a value of 0? Or is it null and does null == 0 in this case?
             String converted = Utils.trimDecimals(conversion.convert(data), conversion.getPrecision());
             message += " (" + converted + conversion.getUnit() + ")";
         }

--- a/src/main/java/edu/whimc/sciencetools/models/sciencetool/NumericScienceTool.java
+++ b/src/main/java/edu/whimc/sciencetools/models/sciencetool/NumericScienceTool.java
@@ -76,7 +76,7 @@ public class NumericScienceTool extends ScienceTool {
             //fixing precision to always be a certain number of decimals so regular measures can be set to precision 0
             //Jack the reason for this is that kids would read 1.000 as one-thousand too easily due to the MC font
             //So for instance on gravity I've made it an integer percent
-            String converted = Utils.trimDecimals(conversion.convert(data), 3);
+            String converted = Utils.trimDecimals(conversion.convert(data), conversion.getPrecision());
             message += " (" + converted + conversion.getUnit() + ")";
         }
 

--- a/src/main/java/edu/whimc/sciencetools/models/sciencetool/QuestsScienceToolObjective.java
+++ b/src/main/java/edu/whimc/sciencetools/models/sciencetool/QuestsScienceToolObjective.java
@@ -3,11 +3,11 @@ package edu.whimc.sciencetools.models.sciencetool;
 import edu.whimc.sciencetools.models.Measurement;
 import edu.whimc.sciencetools.utils.Utils;
 import java.util.Map;
+import org.bukkit.Bukkit;
+import org.bukkit.event.EventHandler;
 import me.pikamug.quests.quests.Quest;
 import me.pikamug.quests.module.BukkitCustomObjective;
 import me.pikamug.quests.Quests;
-import org.bukkit.Bukkit;
-import org.bukkit.event.EventHandler;
 
 /**
  * A custom objective for the Quests plugin.


### PR DESCRIPTION
A quick fix to allow for differing levels for precision in results. Conversions now use a fixed 3 point precision, base numbers use whatever variable is assigned in the config. The reason is that we had too many kids misread the "." and mistake it for a "," and write things like "the gravity is 1000 times that of earth", when it was being expressed as "1.000 times" - I've reworded some of the science tools to match how kids can more logically interpret them: pressure, gravity and radiation are now all "%" of what they would be on earth as the default measure, with specific units that they don't really understand written in the parenthesis in high-precision. So Mars has "38% of earth's gravity" but that's then expressed as 3.727 m/s^2.

A smarter way to do this would be to have a config option for either separate precision for each conversion OR a T/F option for a given science tool to be expressed as percentage. That said my change could be done altering 2 characters in just two files and didn't break anything so I'm going with it for now. Jack I understand if you don't want to merge this and want to do it the right way. I'll make another attempt on this branch for you to review if I can. 